### PR TITLE
Better error messages for , and ,@ outside of `

### DIFF
--- a/src/backquote.lisp
+++ b/src/backquote.lisp
@@ -50,6 +50,13 @@
 (defmacro backquote (x)
   (bq-completely-process x))
 
+;;; The BACKQUOTE macro should remove all occurences of UNQUOTE and
+;;; UNQUOTE-SPLICING from the source before we reach them. If we ever reach
+;;; one, it must have occurred outside a BACKQUOTE form, so we signal the
+;;; appropriate error.
+(defmacro unquote (x) (error "Comma not inside a backquote: ,~S" x))
+(defmacro unquote-splicing (x) (error "Comma-atsign not inside a backquote: ,@~S" x))
+
 ;;; Backquote processing proceeds in three stages:
 ;;;
 ;;; (1) BQ-PROCESS applies the rules to remove occurrences of


### PR DESCRIPTION
Fixes #170

This works by defining a new macro for `CL::UNQUOTE` and `CL::UNQUOTE-SPLICING` which signals the appropriate error. These symbols are usually just used as markers inspected by the `CL::BACKQUOTE` macro, which removes them. So, the only time we should try to macroexpand them is if they were used outside of a backquote. It's in the `CL` package so it shouldn't conflict if a user defines something with the same name.

Now for the testcase in #170, rather than ``Function `UNQUOTE' is undefined.`` we get `Comma not inside a backquote; ,TEST-FORM`