### PR TITLE
Add SICL LOOP implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/sicl"]
+	path = vendor/sicl
+	url = git@github.com:robert-strandh/SICL.git

--- a/jscl.lisp
+++ b/jscl.lisp
@@ -27,6 +27,10 @@
 (defvar *base-directory*
   (or #.*load-pathname* *default-pathname-defaults*))
 
+;;; Load SICL modules
+
+(asdf:load-system :sicl-loop-support)
+
 ;;; List of all the source files that need to be compiled, and whether they
 ;;; are to be compiled just by the host, by the target JSCL, or by both.
 ;;; All files have a `.lisp' extension, and

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -282,8 +282,8 @@
        (cdr ,head))))
 
 
-(defmacro loop (&body body)
-  `(while t ,@body))
+;(defmacro loop (&body body)
+; `(while t ,@body))
 
 (defun identity (x) x)
 

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -673,7 +673,6 @@
           (push-to-lexenv binding  *environment* 'function))))
     (convert `(progn ,@body) *multiple-value-p*)))
 
-
 (defun special-variable-p (x)
   (and (claimp x 'variable 'special) t))
 
@@ -1338,7 +1337,7 @@
 ;; exit are based on try-catch-finally, it will also catch them. We
 ;; could provide a JS function to detect it, so the user could rethrow
 ;; the error.
-;; 
+;;
 ;; (%js-try
 ;;  (progn
 ;;    )
@@ -1346,7 +1345,7 @@
 ;;    )
 ;;  (finally
 ;;   ))
-;; 
+;;
 (define-compilation %js-try (form &optional catch-form finally-form)
   (let ((catch-compilation
          (and catch-form
@@ -1358,7 +1357,7 @@
                   `(catch (,tvar)
                      (= ,tvar (call |js_to_lisp| ,tvar))
                      ,(convert-block body t))))))
-        
+
         (finally-compilation
          (and finally-form
               (destructuring-bind (finally &body body) finally-form
@@ -1371,7 +1370,6 @@
       (try (return ,(convert form)))
       ,catch-compilation
       ,finally-compilation)))
-
 
 #-jscl
 (defvar *macroexpander-cache*
@@ -1416,6 +1414,13 @@
            (values form nil))))
     (t
      (values form nil))))
+
+#-jscl
+(define-compilation loop (&rest forms)
+  (let ((end-tag (gensym)))
+    (convert `(macrolet ((loop-finish ()
+                           `(go ,',end-tag)))
+                ,(sicl-loop::expand-body forms end-tag)))))
 
 (defun compile-funcall (function args)
   (let* ((arglist (cons (if *multiple-value-p* '|values| '|pv|)


### PR DESCRIPTION
This PR adds the LOOP implementation from SICL. It only works at compile time, not on the REPL, but it might be useful to compile other things -- e.g., CLOS -- which can later be used to compile an in-JSCL LOOP implementation.