### PR TITLE
Remove superflous if in digit-char-p

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -327,9 +327,8 @@
       (<= (char-code #\A) (char-code x) (char-code #\Z))))
 
 (defun digit-char-p (x)
-  (if (and (<= (char-code #\0) (char-code x) (char-code #\9)))
-      (- (char-code x) (char-code #\0))
-      nil))
+  (and (<= (char-code #\0) (char-code x) (char-code #\9))
+       (- (char-code x) (char-code #\0))))
 
 (defun digit-char (weight)
   (and (<= 0 weight 9)


### PR DESCRIPTION
title says it all. Another alternative could be to us a when.