### PR TITLE
Don't dump literal table

### DIFF
--- a/jscl.lisp
+++ b/jscl.lisp
@@ -145,7 +145,6 @@
     ;; not collide with the compiler itself.
     (late-compile
      `(progn
-        (setq *literal-table* ',*literal-table*)
         (setq *variable-counter* ,*variable-counter*)
         (setq *gensym-counter* ,*gensym-counter*)))
     (late-compile `(setq *literal-counter* ,*literal-counter*))))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -109,7 +109,7 @@
         (push-to-lexenv b new 'variable)))))
 
 ;;; Toplevel compilations
-(defvar *toplevel-compilations* nil)
+(defvar *toplevel-compilations*)
 
 (defun toplevel-compilation (string)
   (push string *toplevel-compilations*))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -29,7 +29,7 @@
   `(call (function () ,@body)))
 
 (define-js-macro bool (expr)
-  `(if ,expr ,(convert t) ,(convert nil)))
+  `(if ,expr |t| |nil|))
 
 (define-js-macro method-call (x method &rest args)
   `(call (get ,x ,method) ,@args))


### PR DESCRIPTION
This changes removes the necessity of dumping the table of literals in the compiler.

It reduces the output file `jscl.js` size in about a 11%.