### PR TITLE
The #j reader macro only works in jscl

### DIFF
--- a/tests-report.lisp
+++ b/tests-report.lisp
@@ -14,6 +14,7 @@
 
  (terpri)
 
+ #+jscl
  (when #j:phantom
    (#j:phantom:exit *failed-tests*))
 


### PR DESCRIPTION
Hi David,
  Another quickfix, without testing for `jscl` present in the features when running `(jscl:run-tests-in-host)` one gets a read error on the #j reader macro.