### PR TITLE
Add delete-package

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -28,6 +28,19 @@
       package-designator
       (oget *package-table* (string package-designator))))
 
+(defun package-designator-package (package-designator)
+  "Return a package named by the package-designator."
+  (etypecase package-designator
+    (package package-designator)
+    ;; XXX: Merge cases when etypecase supports type specifiers, currently it
+    ;; only supports types
+    (string (find-package package-designator))
+    (symbol (find-package package-designator))))
+
+(defun delete-package (package-designator)
+  (delete-property (package-name (package-designator-package package-designator))
+                   *package-table*))
+
 (defun %make-package (name use)
   (when (find-package name)
     (error "A package namded `~a' already exists." name))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -33,7 +33,7 @@
   ;; name a package.
   ;; TODO: Implement unuse-package and remove the deleted package from packages
   ;; that use it.
-  (delete-property (package-name (find-package package-designator))
+  (delete-property (package-name (find-package-or-fail package-designator))
                    *package-table*))
 
 (defun %make-package (name use)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -28,17 +28,12 @@
       package-designator
       (oget *package-table* (string package-designator))))
 
-(defun package-designator-package (package-designator)
-  "Return a package named by the package-designator."
-  (etypecase package-designator
-    (package package-designator)
-    ;; XXX: Merge cases when etypecase supports type specifiers, currently it
-    ;; only supports types
-    (string (find-package package-designator))
-    (symbol (find-package package-designator))))
-
 (defun delete-package (package-designator)
-  (delete-property (package-name (package-designator-package package-designator))
+  ;; TODO: Signal a correctlable error in case the package-designator does not
+  ;; name a package.
+  ;; TODO: Implement unuse-package and remove the deleted package from packages
+  ;; that use it.
+  (delete-property (package-name (find-package package-designator))
                    *package-table*))
 
 (defun %make-package (name use)

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -4,6 +4,19 @@
 
 (test (equal (multiple-value-list (do-symbols (symbol *package* (values 1 2)))) '(1 2)))
 
+(make-package 'fubar)
+(test (find-package 'fubar))
+(delete-package "FUBAR")
+(test (null (find-package 'fubar)))
+(make-package 'fubar)
+(delete-package 'fubar)
+(test (null (find-package 'fubar)))
+(make-package 'fubar)
+(delete-package (find-package 'fubar))
+(test (null (find-package 'fubar)))
+
+(when (find-package 'foo)
+     (delete-package (find-package 'foo)))
 (test
  (let ((package (make-package 'foo :use '(cl)))
        foo-symbols
@@ -15,6 +28,8 @@
    (and (not (null foo-symbols))
         (equal foo-symbols cl-symbols))))
 
+(when (find-package 'bar)
+   (delete-package (find-package 'bar)))
 (test
  (let* ((package (make-package 'bar))
         (baz (intern (string 'baz) package)))


### PR DESCRIPTION
Hi David,
  This is a crude implementation of delete-package. It still has to handle exceptional situations like deleting a package used in another package.

From the changelog
```
  - Test that one can delete a package with package designators, such as
    a package, a string or symbol
  - Ensure that tests that create a package delete it before creating
    the package to avoid errors when attempting to create an existing
    package when running the test suite in succession.
```

Btw, should the bug about the incorrect typecase be added to the gh issue tracker?