### PR TITLE
Small improvement to format printer

### DIFF
--- a/src/print.lisp
+++ b/src/print.lisp
@@ -287,18 +287,18 @@
 
 #+jscl
 (defun write (form &key (stream *standard-output*))
-  (write-aux form stream))
+  (multiple-value-bind (objs ids)
+      (scan-multiple-referenced-objects form)
+    (write-aux form stream objs ids)
+    form))
 
-(defun !write-to-string (form)
+#+jscl
+(defun write-to-string (form)
   (with-output-to-string (output)
-    (multiple-value-bind (objs ids)
-        (scan-multiple-referenced-objects form)
-      (write-aux form output objs ids))))
-#+jscl (fset 'write-to-string (fdefinition '!write-to-string))
+    (write form :stream output)))
 
 #+jscl
 (progn
-  
   (defun prin1-to-string (form)
     (let ((*print-escape* t))
       (write-to-string form)))

--- a/src/print.lisp
+++ b/src/print.lisp
@@ -218,6 +218,7 @@
              (when package
                (multiple-value-bind (symbol type)
                    (find-symbol name package)
+                 (declare (ignorable symbol))
                  (when (eq type :internal)
                    (write-char #\: stream))))
              (write-string (escape-token name) stream)))))

--- a/src/print.lisp
+++ b/src/print.lisp
@@ -340,40 +340,44 @@
 
 ;;; Format
 
-(defun format-special (destination chr arg)
+(defun format-special (chr arg)
   (case (char-upcase chr)
-    (#\S (prin1 arg destination))
-    (#\A (princ arg destination))
-    (#\D (princ arg destination))
-    (#\~ (write-char #\~ destination))
-    (#\% (write-char #\newline destination))
+    (#\S (prin1-to-string arg))
+    (#\A (princ-to-string arg))
+    (#\D (princ-to-string arg))
     (t
      (warn "~S is not implemented yet, using ~~S instead" chr)
-     (prin1 arg destination))))
+     (prin1-to-string arg))))
 
 (defun !format (destination fmt &rest args)
-  (cond
-    ((null destination)
-     (with-output-to-string (output)
-       (apply #'!format output fmt args)))
-    ((eq destination t)
-     (apply #'!format *standard-output* fmt args))
-    (t
-     (let ((len (length fmt))
-           (i 0)
-           (arguments args))
-       (while (< i len)
-         (let ((c (char fmt i)))
-           (if (char= c #\~)
-               (let ((next (char fmt (incf i))))
-                 (cond
-                   ((char= next #\*)
-                    (pop arguments))
-                   (t
-                    (format-special destination next (car arguments))
-                    (pop arguments))))
-               (write-char c destination))
-           (incf i)))
-       nil))))
+  (let ((len (length fmt))
+        (i 0)
+        (res "")
+        (arguments args))
+    (while (< i len)
+      (let ((c (char fmt i)))
+        (if (char= c #\~)
+            (let ((next (char fmt (incf i))))
+              (cond
+                ((char= next #\~)
+                 (concatf res "~"))
+                ((char= next #\%)
+                 (concatf res (string #\newline)))
+                ((char= next #\*)
+                 (pop arguments))
+                (t
+                 (concatf res (format-special next (car arguments)))
+                 (pop arguments))))
+            (setq res (concat res (string c))))
+        (incf i)))
+
+    (case destination
+      ((t)
+       (write-string res)
+       nil)
+      ((nil)
+       res)
+      (t
+       (write-string res destination)))))
 
 #+jscl (fset 'format (fdefinition '!format))


### PR DESCRIPTION
- Define `princ` and `print1`.
- Modify `format` to work with streams natively, as opposed to generating a string and then printing the string.