### PR TITLE
Add a #J reader macro in host for compatibility

### DIFF
--- a/src/compat.lisp
+++ b/src/compat.lisp
@@ -45,3 +45,11 @@
   (declare (ignorable x))
   ;; (write-line x)
   )
+
+(defun j-reader (stream subchar arg)
+  (declare (ignorable subchar arg))
+  (assert (char= #\: (read-char stream nil :eof)) nil "FFI descriptor must start with a semicolon.")
+  (loop :for ch := (read-char stream nil #\Space)
+        :until (terminalp ch)))
+
+(set-dispatch-macro-character #\# #\J #'j-reader)


### PR DESCRIPTION
  I was testing running under CCL to see if #62 could be closed and found out that `run-tests-in-host` choked when trying to read forms that were under `#+jscl`. Apparently this is [conformant behaviour](http://www.lispworks.com/documentation/HyperSpec/Body/v_rd_sup.htm). The CL reader may continue to read forms after #+ #- so we should provide a reader macro so the reader understands the syntax.

It is not ideal to modify the current-readtable.

All tests pass under CCL.