### PR TITLE
Make reduce work on sequences (Closes #204)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.fasl
 *.fas
+*.lx64fsl
 *.lib
 \#*
 jscl.js

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -77,6 +77,8 @@
 
 (test (equal (reduce #'+ '(100) :key #'1+)
              101))
+(test (= (reduce #'+ #(1 2 3))
+         6))
 
 ; MISMATCH
 (test (= (mismatch '(1 2 3) '(1 2 3 4 5 6)) 3))


### PR DESCRIPTION
My initial version was more readable, but by the time it passed the corner cases in the tests I can't say it is more readable than the previous `do` version. In the long term I think it would be better if we have different versions of reduce and reduce serves as a main entry point that dispatches to the proper version, similar to SBCL. zero-length-sequences and from-end t being the discriminators. This would allow for 'obviously correct' implementations.

It seems possible to reduce repetition in the code a little bit more if we parametrize the associativity of the 'reducer' function, but I did not want to introduce more indirection.

Verified that tests passed on node and on the browser