### PR TITLE
Iterative reduce on sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.fasl
 *.fas
+*.lx64fsl
 *.lib
 \#*
 jscl.js

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -82,6 +82,13 @@
 (test (equal '((Z . C) . D)
              (reduce #'cons #(a b c d e f) :start 2 :end 4 :initial-value 'z)))
 
+;; The following tests reduced reduce were copied from ANSI CL TESTS.
+(test (equal (reduce #'cons '(a b c d e f) :start 1 :end 4 :from-end t)
+             '(b c . d)))
+(test (equal (reduce #'cons '(a b c d e f) :start 1 :end 4 :from-end t
+                                           :initial-value nil)
+             '(b c d)))
+
 ; MISMATCH
 (test (= (mismatch '(1 2 3) '(1 2 3 4 5 6)) 3))
 (test (= (mismatch '(1 2 3) #(1 2 3 4 5 6)) 3))

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -77,6 +77,10 @@
 
 (test (equal (reduce #'+ '(100) :key #'1+)
              101))
+(test (= (reduce #'+ #(1 2 3))
+         6))
+(test (equal '((Z . C) . D)
+             (reduce #'cons #(a b c d e f) :start 2 :end 4 :initial-value 'z)))
 
 ; MISMATCH
 (test (= (mismatch '(1 2 3) '(1 2 3 4 5 6)) 3))


### PR DESCRIPTION
This is an iterative version to address  #204. It is fairly readable although less efficient. For example, We could avoid a funcall for the key function no argument is provided through a macrolet.

The other option would be to tagbody/go approach but that compiles to try/catch IIRC. 