### PR TITLE
seq.lisp: add key "from-end" to position, position-if and position-if-not

### DIFF
--- a/src/sequence.lisp
+++ b/src/sequence.lisp
@@ -77,35 +77,43 @@
           (return x)))))
 
 (defun position (elt sequence
-                 &key key (test #'eql testp)
+                 &key from-end (test #'eql testp)
                    (test-not #'eql test-not-p)
-                   (start 0) end)
+                   (start 0) end key)
   ;; TODO: Implement START and END efficiently for all the sequence
   ;; functions.
-  (let ((end (or end (length sequence))))
+  (let ((end (or end (length sequence)))
+        (output nil))
     (do-sequence (x sequence index)
       (when (and (<= start index)
                  (< index end)
                  (satisfies-test-p elt x
                                    :key key :test test :testp testp
                                    :test-not test-not :test-not-p test-not-p))
-        (return index)))))
+        (setf output index)
+        (unless from-end
+            (return))))
+    output))
 
-;; TODO: need to support &key from-end
 (defun position-if (predicate sequence
-                 &key key (start 0) end)
+                 &key from-end (start 0) end key)
   ;; TODO: Implement START and END efficiently for all the sequence
   ;; functions.
-  (let ((end (or end (length sequence))))
+  (let ((end (or end (length sequence)))
+        (output nil))
     (do-sequence (x sequence index)
       (when (and (<= start index)
                  (< index end)
                  (funcall predicate (if key (funcall key x) x)))
-        (return index)))))
+        (setf output index)
+        (unless from-end
+          (return))))
+    output))
 
 (defun position-if-not (predicate sequence
-                 &key key (start 0) end)
-  (position-if (complement predicate) sequence :key key :start start :end end))
+                 &key from-end (start 0) end key)
+  (position-if (complement predicate) sequence :from-end from-end
+               :start start :end end :key key))
 
 (defun remove (x seq &key key (test #'eql testp) (test-not #'eql test-not-p))
   (cond

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -36,10 +36,15 @@
 (test (= (position '(1 2) #((1 2) (3 4)) :test #'equal) 0))
 (test (= (position 1 #(1 1 3) :test-not #'=) 2))
 (test (= (position 1 '(1 1 3) :test-not #'=) 2))
+(test (= (position 1 '(1 1 3) :from-end nil) 0))
+(test (= (position 1 '(1 1 3) :from-end t) 1))
+(test (= 4 (position #\a "baobab" :from-end t)))
 
 ;; POSITION-IF, POSITION-IF-NOT
 (test (= 2 (position-if #'oddp '((1) (2) (3) (4)) :start 1 :key #'car)))
-(test (= 4 (position-if-not #'integerp '(1 2 3 4 X))))  ;; (hyperspec example used "5.0", but we don't have a full numeric tower yet!)
+(test (= 4 (position-if #'oddp '((1) (2) (3) (4) (5)) :start 1 :key #'car :from-end t))))
+(test (= 4 (position-if-not #'integerp '(1 2 3 4 X Y))))  ;; (hyperspec example used "5.0", but we don't have a full numeric tower yet!)
+(test (= 5 (position-if-not #'integerp '(1 2 3 4 X Y) :from-end t)))
 
 ; REMOVE-IF
 (test (equal (remove-if     #'zerop '(1 0 2 0 3)) '(1 2 3)))


### PR DESCRIPTION
Added support to position functions in seq.lisp to the "from-end" key.
Changed the order of the key arguments in these functions so that it matches with the hyperspec.
Added a few tests related to from-end (only one from clhs, since I couldn't find any other relevant ones).